### PR TITLE
OpenBSD tcpmd5

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -34,4 +34,4 @@ tasks:
       doas rcctl enable bgpd
       doas rcctl start bgpd
   - test: |
-    /home/build/go/bin/bgpipe connect 198.51.100.1:1790 stdout
+      /home/build/go/bin/bgpipe connect 198.51.100.1:1790 stdout

--- a/.build.yml
+++ b/.build.yml
@@ -25,8 +25,8 @@ tasks:
           remote-as 65002
         }
 
-        allow from 192.0.2.1
-        allow to 192.0.2.1
+        allow from 198.51.100.1
+        allow to 198.51.100.1
       EOF
 
       doas mv /tmp/bgpd.conf /etc

--- a/.build.yml
+++ b/.build.yml
@@ -4,6 +4,7 @@ secrets:
   - b2b00838-c8a8-441d-baaa-da121489d0bd
 sources:
   - git@git.sr.ht:~robertkeizer/bgpipe
+  - https://github.com/bgpfix/bgpfix.git
 packages:
   - go
 tasks:

--- a/.build.yml
+++ b/.build.yml
@@ -8,13 +8,14 @@ sources:
 packages:
   - go
 tasks:
-  - install: |
+  - install_bgpipe: |
       cd bgpipe
       go install .
-  - setup_vether: |
+  - setup_vethers: |
       doas ifconfig vether0 198.51.100.1 255.255.255.0 up
+      doas ifconfig vether1 192.0.2.1 255.255.255.0 up
   - setup_bgpd: |
-      doas cat <<EOF>/etc/bgpd.conf
+      cat <<EOF>/tmp/bgpd.conf
         AS 65001
         router-id 198.51.100.1
 
@@ -29,6 +30,7 @@ tasks:
         allow to 192.0.2.1
       EOF
 
+      doas mv /tmp/bgpd.conf /etc
       doas bgpd -vnf /etc/bgpd.conf
       doas rcctl enable bgpd
       doas rcctl start bgpd

--- a/.build.yml
+++ b/.build.yml
@@ -1,5 +1,5 @@
 image: openbsd/7.5
-shell: false
+shell: true
 secrets:
   - b2b00838-c8a8-441d-baaa-da121489d0bd
 sources:
@@ -8,6 +8,27 @@ sources:
 packages:
   - go
 tasks:
-  - test: |
+  - install: |
       cd bgpipe
       go install .
+  - setup_vether: |
+      ifconfig vether0 198.51.100.1 255.255.255.255 up
+  - setup_bgpd: |
+      cat <<EOF>/etc/bgpd.conf
+        AS 65001
+        router-id 198.51.100.1
+
+        listen on 198.51.100.1 port 179
+        network 198.51.100.0/24
+
+        neighbor 192.0.2.1 {
+          remote-as 65002
+        }
+
+        allow from 192.0.2.1
+        allow to 192.0.2.1
+      EOF
+
+      bgpd -vnf /etc/bgpd.conf
+      rcctl enable bgpd
+      rcctl start bgpd

--- a/.build.yml
+++ b/.build.yml
@@ -1,0 +1,12 @@
+image: openbsd/7.5
+shell: false
+secrets:
+  - b2b00838-c8a8-441d-baaa-da121489d0bd
+sources:
+  - git@git.sr.ht:~robertkeizer/bgpipe
+packages:
+  - go
+tasks:
+  - test: |
+      cd bgpipe
+      go install .

--- a/.build.yml
+++ b/.build.yml
@@ -12,9 +12,9 @@ tasks:
       cd bgpipe
       go install .
   - setup_networking: |
-      doas ifconfig vether0 198.51.100.1 255.255.255.0 up
-      doas ifconfig vether1 192.0.2.1 255.255.255.0 up
-      doas route -T1 add 198.51.100.0/24 192.0.2.1
+      doas ifconfig vether1 198.51.100.1 255.255.255.0 up
+      doas ifconfig vether2 192.0.2.1 255.255.255.0 up
+      doas route -T1 add default 198.51.100.1
       doas route -T1 sourceaddr 192.0.2.1
   - setup_bgpd: |
       cat <<EOF>/tmp/bgpd.conf
@@ -37,4 +37,4 @@ tasks:
       doas rcctl enable bgpd
       doas rcctl start bgpd
   - test: |
-      doas route -T1 exec /root/go/bin/bgpipe connect 198.51.100.1 stdout
+      doas route -T1 exec /home/build/go/bin/bgpipe connect 198.51.100.1 stdout

--- a/.build.yml
+++ b/.build.yml
@@ -11,9 +11,11 @@ tasks:
   - install_bgpipe: |
       cd bgpipe
       go install .
-  - setup_vethers: |
+  - setup_networking: |
       doas ifconfig vether0 198.51.100.1 255.255.255.0 up
       doas ifconfig vether1 192.0.2.1 255.255.255.0 up
+      doas route -T1 add 198.51.100.0/24 192.0.2.1
+      doas route -T1 sourceaddr 192.0.2.1
   - setup_bgpd: |
       cat <<EOF>/tmp/bgpd.conf
         AS 65001
@@ -34,3 +36,5 @@ tasks:
       doas bgpd -vnf /etc/bgpd.conf
       doas rcctl enable bgpd
       doas rcctl start bgpd
+  - test: |
+      doas route -T1 exec /root/go/bin/bgpipe connect 198.51.100.1 stdout

--- a/.build.yml
+++ b/.build.yml
@@ -13,18 +13,15 @@ tasks:
       go install .
   - setup_networking: |
       doas ifconfig vether1 198.51.100.1 255.255.255.0 up
-      doas ifconfig vether2 192.0.2.1 255.255.255.0 up
-      doas route -T1 add default 198.51.100.1
-      doas route -T1 sourceaddr 192.0.2.1
   - setup_bgpd: |
       cat <<EOF>/tmp/bgpd.conf
         AS 65001
         router-id 198.51.100.1
 
-        listen on 198.51.100.1 port 179
+        listen on 198.51.100.1 port 1790
         network 198.51.100.0/24
 
-        neighbor 192.0.2.1 {
+        neighbor 198.51.100.1 {
           remote-as 65002
         }
 
@@ -37,4 +34,4 @@ tasks:
       doas rcctl enable bgpd
       doas rcctl start bgpd
   - test: |
-      doas route -T1 exec /home/build/go/bin/bgpipe connect 198.51.100.1 stdout
+    /home/build/go/bin/bgpipe connect 198.51.100.1:1790 stdout

--- a/.build.yml
+++ b/.build.yml
@@ -12,9 +12,9 @@ tasks:
       cd bgpipe
       go install .
   - setup_vether: |
-      ifconfig vether0 198.51.100.1 255.255.255.255 up
+      doas ifconfig vether0 198.51.100.1 255.255.255.0 up
   - setup_bgpd: |
-      cat <<EOF>/etc/bgpd.conf
+      doas cat <<EOF>/etc/bgpd.conf
         AS 65001
         router-id 198.51.100.1
 
@@ -29,6 +29,6 @@ tasks:
         allow to 192.0.2.1
       EOF
 
-      bgpd -vnf /etc/bgpd.conf
-      rcctl enable bgpd
-      rcctl start bgpd
+      doas bgpd -vnf /etc/bgpd.conf
+      doas rcctl enable bgpd
+      doas rcctl start bgpd

--- a/.build.yml
+++ b/.build.yml
@@ -18,7 +18,7 @@ tasks:
         AS 65001
         router-id 198.51.100.1
 
-        listen on 198.51.100.1 port 1790
+        listen on 198.51.100.1
         network 198.51.100.0/24
 
         neighbor 198.51.100.1 {
@@ -34,4 +34,4 @@ tasks:
       doas rcctl enable bgpd
       doas rcctl start bgpd
   - test: |
-      /home/build/go/bin/bgpipe connect 198.51.100.1:1790 stdout
+      /home/build/go/bin/bgpipe connect 198.51.100.1 stdout

--- a/.build.yml
+++ b/.build.yml
@@ -1,5 +1,5 @@
 image: openbsd/7.5
-shell: true
+shell: false
 secrets:
   - b2b00838-c8a8-441d-baaa-da121489d0bd
 sources:

--- a/stages/util_openbsd.go
+++ b/stages/util_openbsd.go
@@ -15,8 +15,13 @@ func tcp_md5(md5pass string) func(net, addr string, c syscall.RawConn) error {
 	return func(net, addr string, c syscall.RawConn) error {
 
     // * Check whether the tcpmd5 SA already exists
-    // * If it doesn't, create a temporary file that can be used to load rules
-    // * Execute ipsecctl -f /path/to/file to load the sa
+    // * If it doesn't, depending on flags:
+    //   * return an error and docs around setting up the sa.
+    //   or
+    //   * create a temporary file that can be used to load rules
+    //   * Execute ipsecctl -f /path/to/file to load the sa
+
+    // https://blog.habets.se/2019/11/TCP-MD5.html
 
 		// setsockopt
 		var err error

--- a/stages/util_openbsd.go
+++ b/stages/util_openbsd.go
@@ -1,0 +1,34 @@
+//go:build openbsd
+
+package stages
+
+import (
+	"syscall"
+  "golang.org/x/sys/unix"
+)
+
+func tcp_md5(md5pass string) func(net, addr string, c syscall.RawConn) error {
+	if len(md5pass) == 0 {
+		return nil
+	}
+
+	return func(net, addr string, c syscall.RawConn) error {
+
+    // * Check whether the tcpmd5 SA already exists
+    // * If it doesn't, create a temporary file that can be used to load rules
+    // * Execute ipsecctl -f /path/to/file to load the sa
+
+		// setsockopt
+		var err error
+		c.Control(func(fd uintptr) {
+
+      /*
+      Future: 0x04 comes from https://github.com/openbsd/src/blob/master/sys/netinet/tcp.h#L217
+      While it is unlikely to change, looking it up would be better rather than having it hardcoded.
+      */
+
+			err = unix.SetsockoptString(int(fd), unix.IPPROTO_TCP, 0x04, string("tcpmd5string"))
+		})
+		return err
+	}
+}

--- a/stages/util_unsupported.go
+++ b/stages/util_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build (!linux && !openbsd)
 
 package stages
 


### PR DESCRIPTION
### Context / Background
I wanted to use `bgpipe` on OpenBSD with the TCP MD5 signatures option. I was able to fairly easily "make it work", but I'd like to see about supporting the platform more generally.

On OpenBSD to facilitate TCP MD5 signatures, a  _security association_ must be setup on the system, in addition to setting a flag on the socket. I also found that `unix.TCP_MD5SIG_EXT` was not available.

I was able to use `unix.SetsockoptString(int(fd), unix.IPPROTO_TCP, 0x04, string("..."))` in addition to previously loading a security association on the machine to make this work.

To load the security association I used `ipsecctl -f /tmp/tcpmd5.conf` with the following defined ( roughly )

`/tmp/tcpmd5.conf` 
```
tcpmd5 from 198.51.100.1 to 198.51.100.2 spi 0x100 authkey 0x0000000000
tcpmd5 from 198.51.100.2to 198.51.100.1 spi 0x101 authkey 0x0000000000
```

On OpenBSD I would expect most programs to not define and create the security associations, but rather error out if the security associations weren't defined and tcp md5 signatures were required.

 * https://man.openbsd.org/tcp.4
 * https://man.openbsd.org/ipsec.conf.5#tcpmd5~2
 * https://blog.habets.se/2019/11/TCP-MD5.html

### Question

 * What are your thoughts on supporting OpenBSD?
 * Would you prefer to:
   * Attempt to dynamically create the security associations in favour of usability?
   * Error out if the md5 flag is set and a security association could not found or there is an error setting the socket option?

I would strongly suspect most people running OpenBSD would prefer the latter (simply error out), but this isn't my project, so I figure opening a draft PR and asking the question is the more appropriate path.